### PR TITLE
Adsk Contrib - Add cmake option OCIO_ARCHIVE_SUPPORT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ option(OCIO_BUILD_DOCS "Specify whether to build documentation" ${OCIO_BUILD_FRO
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
 
 option(OCIO_USE_HALF_LOOKUP_TABLE "Determines if the Imath library should use a 64k LUT for half conversions" ON)
+option(OCIO_ARCHIVE_SUPPORT "Specify whether to build with OCIOZ archive support. Requires ZLIB and minizip-ng dependencies" ON)
 
 set (OCIO_PYTHON_VERSION "" CACHE STRING
      "Preferred Python version (if any) in case multiple are available")

--- a/include/OpenColorIO/OpenColorABI.h.in
+++ b/include/OpenColorIO/OpenColorABI.h.in
@@ -26,6 +26,8 @@
 #define OCIO_VERSION_MAJOR @OpenColorIO_VERSION_MAJOR@
 #define OCIO_VERSION_MINOR @OpenColorIO_VERSION_MINOR@
 
+// Experimental switches to streamline OCIO library.
+#cmakedefine01  OCIO_ARCHIVE_SUPPORT
 
 // Highlight deprecated methods or classes.
 #if defined(_MSC_VER)

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -228,6 +228,7 @@ extern OCIOEXPORT void SetCurrentConfig(const ConstConfigRcPtr & config);
  */
 extern OCIOEXPORT const char * ResolveConfigPath(const char * originalPath) noexcept;
 
+#if OCIO_ARCHIVE_SUPPORT
 /**
  * \brief Extract an OCIO Config archive.
  * 
@@ -247,6 +248,7 @@ extern OCIOEXPORT void ExtractOCIOZArchive(
     const char * archivePath, 
     const char * destinationDir
 );
+#endif //OCIO_ARCHIVE_SUPPORT
 
 /**
  * \brief
@@ -1480,6 +1482,7 @@ public:
     void setConfigIOProxy(ConfigIOProxyRcPtr ciop);
     ConfigIOProxyRcPtr getConfigIOProxy() const;
 
+#if OCIO_ARCHIVE_SUPPORT
     /**
      * \brief Verify if the config is archivable.
      *
@@ -1530,6 +1533,7 @@ public:
      * \param ostream The output stream to write to.
      */
     void archive(std::ostream & ostream) const;
+#endif //OCIO_ARCHIVE_SUPPORT
 
     Config(const Config &) = delete;
     Config& operator= (const Config &) = delete;

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1482,7 +1482,6 @@ public:
     void setConfigIOProxy(ConfigIOProxyRcPtr ciop);
     ConfigIOProxyRcPtr getConfigIOProxy() const;
 
-#if OCIO_ARCHIVE_SUPPORT
     /**
      * \brief Verify if the config is archivable.
      *
@@ -1508,6 +1507,7 @@ public:
      */
     bool isArchivable() const;
 
+#if OCIO_ARCHIVE_SUPPORT
     /**
      * \brief Archive the config and its LUTs into the specified output stream.
      * 

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -80,40 +80,7 @@ ocio_handle_dependency(  Imath REQUIRED ALLOW_INSTALL
                          RECOMMENDED_VERSION 3.1.6
                          RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
 
-###############################################################################
-# ZLIB (https://github.com/madler/zlib)
-#
-# The following variables can be set:
-# ZLIB_ROOT               Location of ZLIB library file and includes folder.
-#                         Alternatively, ZLIB_LIBRARY and ZLIB_INCLUDE_DIR can be used.
-#
-# ZLIB_LIBRARY            Location of ZLIB library file.
-# ZLIB_INCLUDE_DIR        Location of ZLIB includes folder.
-#
-# ZLIB_VERSION            ZLIB Version (CMake 3.26+)
-# ZLIB_VERSION_STRING     ZLIB Version (CMake < 3.26)
-#
-#
-# ZLIB_USE_STATIC_LIBS    Set to ON if static library is prefered (CMake 3.24+)
-#
-###############################################################################
-# ZLIB 1.2.13 is used since it fixes a critical vulnerability.
-# See https://nvd.nist.gov/vuln/detail/CVE-2022-37434
-# See https://github.com/madler/zlib/releases/tag/v1.2.13
-ocio_handle_dependency(  ZLIB REQUIRED ALLOW_INSTALL
-                         MIN_VERSION 1.2.8
-                         RECOMMENDED_VERSION 1.2.13
-                         RECOMMENDED_VERSION_REASON "CVE fixes"
-                         VERSION_VARS ZLIB_VERSION_STRING ZLIB_VERSION )
 
-###############################################################################
-
-# minizip-ng
-# https://github.com/zlib-ng/minizip-ng
-ocio_handle_dependency(  minizip-ng REQUIRED ALLOW_INSTALL
-                         MIN_VERSION 3.0.6
-                         RECOMMENDED_VERSION 3.0.7
-                         RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
 
 ###############################################################################
 ##
@@ -122,6 +89,43 @@ ocio_handle_dependency(  minizip-ng REQUIRED ALLOW_INSTALL
 ###############################################################################
 message(STATUS "")
 message(STATUS "Checking for optional dependencies...")
+
+if(OCIO_ARCHIVE_SUPPORT)
+    ###############################################################################
+    # ZLIB (https://github.com/madler/zlib)
+    #
+    # The following variables can be set:
+    # ZLIB_ROOT               Location of ZLIB library file and includes folder.
+    #                         Alternatively, ZLIB_LIBRARY and ZLIB_INCLUDE_DIR can be used.
+    #
+    # ZLIB_LIBRARY            Location of ZLIB library file.
+    # ZLIB_INCLUDE_DIR        Location of ZLIB includes folder.
+    #
+    # ZLIB_VERSION            ZLIB Version (CMake 3.26+)
+    # ZLIB_VERSION_STRING     ZLIB Version (CMake < 3.26)
+    #
+    #
+    # ZLIB_USE_STATIC_LIBS    Set to ON if static library is prefered (CMake 3.24+)
+    #
+    ###############################################################################
+    # ZLIB 1.2.13 is used since it fixes a critical vulnerability.
+    # See https://nvd.nist.gov/vuln/detail/CVE-2022-37434
+    # See https://github.com/madler/zlib/releases/tag/v1.2.13
+    ocio_handle_dependency(  ZLIB REQUIRED ALLOW_INSTALL
+                             MIN_VERSION 1.2.8
+                             RECOMMENDED_VERSION 1.2.13
+                             RECOMMENDED_VERSION_REASON "CVE fixes"
+                             VERSION_VARS ZLIB_VERSION_STRING ZLIB_VERSION )
+
+    ###############################################################################
+
+    # minizip-ng
+    # https://github.com/zlib-ng/minizip-ng
+    ocio_handle_dependency(  minizip-ng REQUIRED ALLOW_INSTALL
+                             MIN_VERSION 3.0.6
+                             RECOMMENDED_VERSION 3.0.7
+                             RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
+endif()
 
 if(OCIO_BUILD_APPS)
     # NOTE: Depending of the compiler version lcms2 2.2 does not compile with 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -319,8 +319,11 @@ target_link_libraries(OpenColorIO
         "$<BUILD_INTERFACE:utils::strings>"
         "$<BUILD_INTERFACE:xxHash>"
         ${YAML_CPP_LIBRARIES}
-        MINIZIP::minizip-ng
 )
+
+if(OCIO_ARCHIVE_SUPPORT)
+    target_link_libraries(OpenColorIO PRIVATE MINIZIP::minizip-ng)
+endif()
 
 if(OCIO_USE_SIMD AND OCIO_USE_SSE2NEON AND COMPILER_SUPPORTS_SSE_WITH_SSE2NEON)
     target_link_libraries(OpenColorIO PRIVATE $<BUILD_INTERFACE:sse2neon>)

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -5483,7 +5483,6 @@ ConfigIOProxyRcPtr Config::getConfigIOProxy() const
 {
     return getImpl()->m_context->getConfigIOProxy();
 }
-#if OCIO_ARCHIVE_SUPPORT
 bool Config::isArchivable() const
 {
     ConstContextRcPtr context = getCurrentContext();
@@ -5558,6 +5557,7 @@ bool Config::isArchivable() const
 
     return true;
 }
+#if OCIO_ARCHIVE_SUPPORT
 
 void Config::archive(std::ostream & ostream) const
 {

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -1179,6 +1179,7 @@ ConstConfigRcPtr Config::CreateFromFile(const char * filename)
         throw Exception (os.str().c_str());
     }
 
+#if OCIO_ARCHIVE_SUPPORT
     char magicNumber[2] = { 0 };
     if (ifstream.read(magicNumber, 2))
     {
@@ -1198,7 +1199,7 @@ ConstConfigRcPtr Config::CreateFromFile(const char * filename)
             return CreateFromConfigIOProxy(ciop);
         }
     } 
-
+#endif //OCIO_ARCHIVE_SUPPORT
     // Not an OCIOZ archive. Continue as usual.
     ifstream.clear();
     ifstream.seekg(0);
@@ -5482,7 +5483,7 @@ ConfigIOProxyRcPtr Config::getConfigIOProxy() const
 {
     return getImpl()->m_context->getConfigIOProxy();
 }
-
+#if OCIO_ARCHIVE_SUPPORT
 bool Config::isArchivable() const
 {
     ConstContextRcPtr context = getCurrentContext();
@@ -5563,5 +5564,5 @@ void Config::archive(std::ostream & ostream) const
     // Using utility functions in OCIOZArchive.cpp.
     archiveConfig(ostream, *this, getCurrentContext()->getWorkingDir());
 }
-
+#endif //OCIO_ARCHIVE_SUPPORT
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/OCIOZArchive.cpp
+++ b/src/OpenColorIO/OCIOZArchive.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
+#include <OpenColorIO/OpenColorIO.h>
+#if OCIO_ARCHIVE_SUPPORT
 
 #include <sstream>
 #include <fstream>
@@ -10,7 +12,6 @@
 
 #include <pystring.h>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 #include "Mutex.h"
 #include "Platform.h"
@@ -652,3 +653,5 @@ void CIOPOciozArchive::buildEntries()
 }
 
 } // namespace OCIO_NAMESPACE
+
+#endif //OCIO_ARCHIVE_SUPPORT

--- a/src/OpenColorIO/OCIOZArchive.h
+++ b/src/OpenColorIO/OCIOZArchive.h
@@ -5,13 +5,16 @@
 #ifndef INCLUDED_OCIO_ARCHIVEUTILS_H
 #define INCLUDED_OCIO_ARCHIVEUTILS_H
 
+#include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_ARCHIVE_SUPPORT
+
 #include <sstream>
 #include <fstream>
 #include <vector>
 #include <map>
 #include <string>
 
-#include <OpenColorIO/OpenColorIO.h>
 
 namespace OCIO_NAMESPACE
 {
@@ -108,4 +111,5 @@ private:
 
 } // namespace OCIO_NAMESPACE
 
+#endif //OCIO_ARCHIVE_SUPPORT
 #endif

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright Contributors to the OpenColorIO Project.
 
 if(OCIO_BUILD_APPS)
-	add_subdirectory(ocioarchive)
 	add_subdirectory(ociobakelut)
 	add_subdirectory(ociocheck)
 	add_subdirectory(ociochecklut)
@@ -10,6 +9,10 @@ if(OCIO_BUILD_APPS)
 	add_subdirectory(ociomakeclf)
 	add_subdirectory(ocioperf)
 	add_subdirectory(ociowrite)
+
+	if(OCIO_ARCHIVE_SUPPORT)
+		add_subdirectory(ocioarchive)
+	endif()
 
 	if(TARGET OpenColorIO::ImageIOBackend)
 		add_subdirectory(ociolutimage)

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -37,9 +37,12 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
             utils::strings
             ${YAML_CPP_LIBRARIES}
             testutils
-            MINIZIP::minizip-ng
             xxHash
     )
+
+    if(OCIO_ARCHIVE_SUPPORT)
+        target_link_libraries(${TEST_BINARY} PRIVATE MINIZIP::minizip-ng)
+    endif()
 
     if(OCIO_USE_SIMD AND OCIO_USE_SSE2NEON AND COMPILER_SUPPORTS_SSE_WITH_SSE2NEON)
         target_link_libraries(${TEST_BINARY} PRIVATE sse2neon)

--- a/tests/cpu/OCIOZArchive_tests.cpp
+++ b/tests/cpu/OCIOZArchive_tests.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include "OpenColorIO/OpenColorIO.h"
+#if OCIO_ARCHIVE_SUPPORT
+
 #include "testutils/UnitTest.h"
 #include "UnitTestUtils.h"
 
@@ -572,3 +574,5 @@ OCIO_ADD_TEST(OCIOZArchive, extract_config_and_compare_to_original)
         );
     }
 }
+
+#endif //OCIO_ARCHIVE_SUPPORT


### PR DESCRIPTION
Another simple cmake flag to add: OCIO_ARCHIVE_SUPPORT.

When OFF, this will remove the archive functionality and the dependencies to ZLIB and minizip-ng.