### PR TITLE
Adsk Contrib - Add cmake option OCIO_HAS_BUILTIN_YAML_CONFIGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ option(OCIO_BUILD_DOCS "Specify whether to build documentation" ${OCIO_BUILD_FRO
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
 
 option(OCIO_USE_HALF_LOOKUP_TABLE "Determines if the Imath library should use a 64k LUT for half conversions" ON)
+option(OCIO_HAS_BUILTIN_YAML_CONFIGS "If OFF, built-in yaml-based configs will be removed from the library" ON)
 
 set (OCIO_PYTHON_VERSION "" CACHE STRING
      "Preferred Python version (if any) in case multiple are available")

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -224,6 +224,10 @@ endif()
 if(NOT OCIO_USE_HALF_LOOKUP_TABLE)
     add_compile_definitions(IMATH_HALF_NO_LOOKUP_TABLE)
 endif()
+if(OCIO_HAS_BUILTIN_YAML_CONFIGS)
+    add_compile_definitions(OCIO_HAS_BUILTIN_YAML_CONFIGS)
+endif()
+
 
 configure_file(CPUInfoConfig.h.in CPUInfoConfig.h)
 

--- a/src/OpenColorIO/builtinconfigs/BuiltinConfigRegistry.cpp
+++ b/src/OpenColorIO/builtinconfigs/BuiltinConfigRegistry.cpp
@@ -85,8 +85,10 @@ void BuiltinConfigRegistryImpl::init() noexcept
     {
         m_builtinConfigs.clear();
         
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
         CGCONFIG::Register(*this);
         STUDIOCONFIG::Register(*this);
+#endif //OCIO_HAS_BUILTIN_YAML_CONFIGS
     }
 }
 

--- a/src/OpenColorIO/builtinconfigs/CGConfig.cpp
+++ b/src/OpenColorIO/builtinconfigs/CGConfig.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 #include "builtinconfigs/BuiltinConfigRegistry.h"
 #include "builtinconfigs/CGConfig.h"
 
@@ -37,3 +39,4 @@ void Register(BuiltinConfigRegistryImpl & registry) noexcept
 
 } // namespace CGCONFIG
 } // namespace OCIO_NAMESPACE
+#endif // OCIO_HAS_BUILTIN_YAML_CONFIGS

--- a/src/OpenColorIO/builtinconfigs/CGConfig.h
+++ b/src/OpenColorIO/builtinconfigs/CGConfig.h
@@ -7,6 +7,8 @@
 
 
 #include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 #include "builtinconfigs/BuiltinConfigRegistry.h"
 
 namespace OCIO_NAMESPACE
@@ -21,4 +23,5 @@ namespace CGCONFIG
 
 } // namespace OCIO_NAMESPACE
 
+#endif // OCIO_HAS_BUILTIN_YAML_CONFIGS
 #endif // INCLUDED_OCIO_CGCONFIG_H

--- a/src/OpenColorIO/builtinconfigs/StudioConfig.cpp
+++ b/src/OpenColorIO/builtinconfigs/StudioConfig.cpp
@@ -2,6 +2,8 @@
 // Copyright Contributors to the OpenColorIO Project.
 
 #include <OpenColorIO/OpenColorIO.h>
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
+
 #include "builtinconfigs/BuiltinConfigRegistry.h"
 #include "builtinconfigs/StudioConfig.h"
 
@@ -37,3 +39,4 @@ void Register(BuiltinConfigRegistryImpl & registry) noexcept
 
 } // namespace STUDIOCONFIG
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_HAS_BUILTIN_YAML_CONFIGS

--- a/src/OpenColorIO/builtinconfigs/StudioConfig.h
+++ b/src/OpenColorIO/builtinconfigs/StudioConfig.h
@@ -5,8 +5,9 @@
 #ifndef INCLUDED_OCIO_STUDIOCONFIG_H
 #define INCLUDED_OCIO_STUDIOCONFIG_H
 
-
 #include <OpenColorIO/OpenColorIO.h>
+
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 #include "builtinconfigs/BuiltinConfigRegistry.h"
 
 namespace OCIO_NAMESPACE
@@ -20,5 +21,6 @@ namespace STUDIOCONFIG
 } // namespace STUDIOCONFIG
 
 } // namespace OCIO_NAMESPACE
+#endif //OCIO_HAS_BUILTIN_YAML_CONFIGS
 
 #endif // INCLUDED_OCIO_STUDIOCONFIG_H

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -976,6 +976,7 @@ colorspaces:
     }
 }
 
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 OCIO_ADD_TEST(ConfigUtils, processor_to_known_colorspace)
 {
     constexpr const char * CONFIG { R"(
@@ -1688,3 +1689,4 @@ colorspaces:
         );
     }
 }
+#endif //OCIO_HAS_BUILTIN_YAML_CONFIGS

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -5743,6 +5743,7 @@ OCIO_ADD_TEST(Config, inactive_color_space)
                                                       OCIO::COLORSPACE_ALL, 1));
 }
 
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 OCIO_ADD_TEST(Config, is_inactive)
 {
     // Using Built-in config to test the getInactiveColorSpace method.
@@ -5770,6 +5771,8 @@ OCIO_ADD_TEST(Config, is_inactive)
         OCIO_CHECK_EQUAL(config->isInactiveColorSpace("Rec.1886 Rec.2020 - Display"), true);
     }
 }
+#endif //OCIO_HAS_BUILTIN_YAML_CONFIGS
+
 
 OCIO_ADD_TEST(Config, inactive_color_space_precedence)
 {

--- a/tests/cpu/builtinconfigs/BuiltinConfig_tests.cpp
+++ b/tests/cpu/builtinconfigs/BuiltinConfig_tests.cpp
@@ -16,7 +16,7 @@ namespace OCIO = OCIO_NAMESPACE;
 OCIO_ADD_TEST(BuiltinConfigs, basic)
 {
     const OCIO::BuiltinConfigRegistry & registry = OCIO::BuiltinConfigRegistry::Get();
-    
+#if(OCIO_HAS_BUILTIN_YAML_CONFIGS)    
     OCIO_CHECK_EQUAL(registry.getNumBuiltinConfigs(), 4);
 
     // Test builtin config cg-config-v1.0.0_aces-v1.3_ocio-v2.1.
@@ -130,6 +130,9 @@ OCIO_ADD_TEST(BuiltinConfigs, basic)
 
         OCIO_CHECK_EQUAL(registry.isBuiltinConfigRecommended(3), true);
     }
+#else // OCIO_HAS_BUILTIN_YAML_CONFIGS
+    OCIO_CHECK_EQUAL(registry.getNumBuiltinConfigs(), 0);
+#endif // OCIO_HAS_BUILTIN_YAML_CONFIGS
 
     // ********************************
     // Testing some expected failures.
@@ -232,6 +235,7 @@ OCIO_ADD_TEST(BuiltinConfigs, basic_impl)
     }
 }
 
+#if OCIO_HAS_BUILTIN_YAML_CONFIGS
 OCIO_ADD_TEST(BuiltinConfigs, create_builtin_config)
 {
     auto testFromBuiltinConfig = [](const std::string name,
@@ -398,6 +402,7 @@ OCIO_ADD_TEST(BuiltinConfigs, create_builtin_config)
         );
     }
 }
+#endif // OCIO_HAS_BUILTIN_YAML_CONFIGS
 
 OCIO_ADD_TEST(BuiltinConfigs, resolve_config_path)
 {


### PR DESCRIPTION
Adding cmake option to remove built-in yaml based configs (CGConfig and StudioConfig). When this option is turned off, the tests that rely on the built-in configs will also be removed.