### PR TITLE
Add MatrixTransform factory from chromaticities

### DIFF
--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -1789,7 +1789,7 @@ extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Lut3DTransform&
 #endif // OCIO_LUT_AND_FILETRANSFORM_SUPPORT
 
 /// A pair of chromaticity coordinates.
-struct Chromaticities
+struct OCIOEXPORT Chromaticities
 {
     Chromaticities() = delete;
     ~Chromaticities() = default;

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -1788,6 +1788,75 @@ protected:
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Lut3DTransform&);
 #endif // OCIO_LUT_AND_FILETRANSFORM_SUPPORT
 
+/// A pair of chromaticity coordinates.
+struct Chromaticities
+{
+    Chromaticities() = delete;
+    ~Chromaticities() = default;
+
+    Chromaticities(double x, double y)
+    {
+        m_xy[0] = x;
+        m_xy[1] = y;
+    }
+
+    Chromaticities(const Chromaticities & xy)
+    {
+        m_xy[0] = xy.m_xy[0];
+        m_xy[1] = xy.m_xy[1];
+    }
+
+    Chromaticities & operator=(const Chromaticities & xy)
+    {
+        if (this == &xy) return *this;
+
+        m_xy[0] = xy.m_xy[0];
+        m_xy[1] = xy.m_xy[1];
+
+        return *this;
+    }
+
+    double m_xy[2] { 0., 0. };
+};
+
+/// A set of color primaries, consisting of R, G, B, and white chromaticities.
+struct OCIOEXPORT Primaries
+{
+    Primaries() = delete;
+    ~Primaries() = default;
+
+    Primaries(const Chromaticities & red, const Chromaticities & grn, const Chromaticities & blu,
+              const Chromaticities & wht)
+        :   m_red(red)
+        ,   m_grn(grn)
+        ,   m_blu(blu)
+        ,   m_wht(wht)
+    {}
+
+    Primaries(const Primaries & primaries)
+        :   m_red(primaries.m_red)
+        ,   m_grn(primaries.m_grn)
+        ,   m_blu(primaries.m_blu)
+        ,   m_wht(primaries.m_wht)
+    {}
+
+    Primaries & operator=(const Primaries & primaries)
+    {
+        if (this == &primaries) return *this;
+
+        m_red = primaries.m_red;
+        m_grn = primaries.m_grn;
+        m_blu = primaries.m_blu;
+        m_wht = primaries.m_wht;
+
+        return *this;
+    }
+
+    Chromaticities m_red; // CIE xy chromaticity coordinates for red primary.
+    Chromaticities m_grn; // CIE xy chromaticity coordinates for green primary.
+    Chromaticities m_blu; // CIE xy chromaticity coordinates for blue primary.
+    Chromaticities m_wht; // CIE xy chromaticities for white (or gray).
+};
 
 /**
  * Represents an MX+B Matrix transform.
@@ -1877,6 +1946,21 @@ public:
     static void View(double * m44, double * offset4,
                      int * channelHot4,
                      const double * lumaCoef3);
+
+    /// Generate a matrix to convert RGB values in a given set of color primaries
+    /// to CIE XYZ. The white point of the primaries is mapped to D65 using the
+    /// specified chromatic adaptation method. (The offsets are always 0.)
+    static void ConvertTo_XYZ_D65(double * m44, double * offset4,
+                                  const Primaries & src_prims,
+                                  AdaptationMethod method);
+
+    /// Generate a matrix to convert RGB values in a given set of color primaries
+    /// to the AP0 primaries used in ACES2065-1. The white point of the primaries
+    /// is mapped to D60 using the specified chromatic adaptation method. (The offsets
+    /// are always 0.)
+    static void ConvertTo_AP0(double * m44, double * offset4,
+                              const Primaries & src_prims,
+                              AdaptationMethod method);
 
     MatrixTransform(const MatrixTransform &) = delete;
     MatrixTransform & operator= (const MatrixTransform &) = delete;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -430,6 +430,14 @@ enum Lut1DHueAdjust
     HUE_WYPN      ///< Weighted Yellow Power Norm -- NOT IMPLEMENTED YET
 };
 
+/// Chromatic adaptation method.
+enum AdaptationMethod
+{
+    ADAPTATION_NONE = 0,
+    ADAPTATION_BRADFORD,
+    ADAPTATION_CAT02
+};
+
 /// Used by \ref PackedImageDesc to indicate the channel ordering of the image to process.
 enum ChannelOrdering
 {

--- a/src/OpenColorIO/transforms/MatrixTransform.cpp
+++ b/src/OpenColorIO/transforms/MatrixTransform.cpp
@@ -7,6 +7,7 @@
 
 #include "MathUtils.h"
 #include "transforms/MatrixTransform.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
 
 namespace OCIO_NAMESPACE
 {
@@ -330,6 +331,57 @@ void MatrixTransform::View(double * m44, double * offset4,
             // Preserve alpha
             m44[15] = 1.0;
         }
+    }
+}
+
+void MatrixTransform::ConvertTo_XYZ_D65(double * m44, double * offset4,
+                                        const Primaries & src_prims,
+                                        AdaptationMethod method)
+{
+    if(!m44)
+    {
+        return;
+    }
+
+    MatrixOpData::MatrixArrayPtr matrix = build_conversion_matrix_to_XYZ_D65(src_prims,
+                                                                             method);
+    for(int i = 0; i < 16; ++i)
+    {
+        m44[i] = matrix->getDoubleValue(i);
+    }
+
+    if(offset4)
+    {
+        offset4[0] = 0.0;
+        offset4[1] = 0.0;
+        offset4[2] = 0.0;
+        offset4[3] = 0.0;
+    }
+}
+
+void MatrixTransform::ConvertTo_AP0(double * m44, double * offset4,
+                                    const Primaries & src_prims,
+                                    AdaptationMethod method)
+{
+    if(!m44)
+    {
+        return;
+    }
+
+    MatrixOpData::MatrixArrayPtr matrix = build_conversion_matrix(src_prims,
+                                                                  ACES_AP0::primaries,
+                                                                  method);
+    for(int i = 0; i < 16; ++i)
+    {
+        m44[i] = matrix->getDoubleValue(i);
+    }
+
+    if(offset4)
+    {
+        offset4[0] = 0.0;
+        offset4[1] = 0.0;
+        offset4[2] = 0.0;
+        offset4[3] = 0.0;
     }
 }
 

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
@@ -14,74 +14,6 @@
 namespace OCIO_NAMESPACE
 {
 
-struct Chromaticities
-{
-    Chromaticities() = delete;
-    ~Chromaticities() = default;
-
-    Chromaticities(double x, double y)
-    {
-        m_xy[0] = x;
-        m_xy[1] = y;
-    }
-
-    Chromaticities(const Chromaticities & xy)
-    {
-        m_xy[0] = xy.m_xy[0];
-        m_xy[1] = xy.m_xy[1];
-    }
-
-    Chromaticities & operator=(const Chromaticities & xy)
-    {
-        if (this == &xy) return *this;
-
-        m_xy[0] = xy.m_xy[0];
-        m_xy[1] = xy.m_xy[1];
-
-        return *this;
-    }
-
-    double m_xy[2] { 0., 0. };
-};
-
-struct Primaries
-{
-    Primaries() = delete;
-    ~Primaries() = default;
-
-    Primaries(const Chromaticities & red, const Chromaticities & grn, const Chromaticities & blu,
-              const Chromaticities & wht)
-        :   m_red(red)
-        ,   m_grn(grn)
-        ,   m_blu(blu)
-        ,   m_wht(wht)
-    {}
-
-    Primaries(const Primaries & primaries)
-        :   m_red(primaries.m_red)
-        ,   m_grn(primaries.m_grn)
-        ,   m_blu(primaries.m_blu)
-        ,   m_wht(primaries.m_wht)
-    {}
-
-    Primaries & operator=(const Primaries & primaries)
-    {
-        if (this == &primaries) return *this;
-
-        m_red = primaries.m_red;
-        m_grn = primaries.m_grn;
-        m_blu = primaries.m_blu;
-        m_wht = primaries.m_wht;
-
-        return *this;
-    }
-
-    Chromaticities m_red; // CIE xy chromaticity coordinates for red primary.
-    Chromaticities m_grn; // CIE xy chromaticity coordinates for green primary.
-    Chromaticities m_blu; // CIE xy chromaticity coordinates for blue primary.
-    Chromaticities m_wht; // CIE xy chromaticities for white (or gray).
-};
-
 namespace CIE_XYZ_ILLUM_E
 {
 extern const Primaries primaries;
@@ -138,13 +70,6 @@ extern const MatrixOpData::Offsets DCI_XYZ;
 //        Z = rgb2xyz[2][0] * R + rgb2xyz[2][1] * G + rgb2xyz[2][2] * B;
 
 MatrixOpData::MatrixArrayPtr rgb2xyz_from_xy(const Primaries & chromaticities);
-
-enum AdaptationMethod
-{
-    ADAPTATION_NONE = 0,
-    ADAPTATION_BRADFORD,
-    ADAPTATION_CAT02
-};
 
 // Build a von Kries type chromatic adaptation matrix from source white point src_XYZ to 
 // destination white point dst_XYZ, using the chosen cone primary matrix.


### PR DESCRIPTION
Adds two additional helper functions to the MatrixTransform class for creating a transform from a given set of primaries to either CIE-XYZ-D65 or AP0, with a choice of adaptation methods.

The underlying functions were already present for use in the built-in transforms, but were not exposed to the public API until now.

A unit test demonstrates how to use the new methods to create a custom color space and add it to a config.

TODO: Add the new functions to the Python binding.